### PR TITLE
Fix db not work with heroku.

### DIFF
--- a/grimas/grima-lib.php
+++ b/grimas/grima-lib.php
@@ -3159,6 +3159,19 @@ class GrimaDB implements ArrayAccess, IteratorAggregate {
 		if (!self::$db) {
 			$db_url = getenv('DATABASE_URL');
 			if (!$db_url) $db_url = "sqlite:" . join_paths( sys_get_temp_dir(), "grima/grima.sql");
+
+			// @see: https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-php
+			if (strpos($db_url, "postgres") == 0) {
+				$db = parse_url($db_url);
+				$db_url =  "pgsql:" . sprintf(
+					"host=%s;port=%s;user=%s;password=%s;dbname=%s",
+					$db["host"],
+					$db["port"],
+					$db["user"],
+					$db["pass"],
+					ltrim($db["path"], "/"));
+			}
+
 			self::$db = new PDO($db_url);
 		}
 		return self::$db;


### PR DESCRIPTION
The DATABASE_URL that heroku sets is not in DSN format as PDO
requires.  This commit checks if the DB URI given starts with 'postgres'
then parses it and generates the equivalent DSN version.