### PR TITLE
Fix invalid input syntax for type boolean: "2"

### DIFF
--- a/grimas/AdminAddInstitution/AdminAddInstitution.php
+++ b/grimas/AdminAddInstitution/AdminAddInstitution.php
@@ -43,7 +43,7 @@ class AdminAddInstitution extends GrimaTask {
 		$newAdmin['username'] = $this['username'];
 		$newAdmin['password'] = $this['password'];
 		$newAdmin['institution'] = $this['institution'];
-		$newAdmin['isAdmin'] = $firstRun ? 2 : 1;
+		$newAdmin['isAdmin'] = $firstRun ? true : false;
 		$newAdmin->addToDB();
 		$this->addMessage('success',"User '{$newAdmin['username']}' successfully added as admin of '{$inst['institution']}'.");
 		GrimaUser::SetCurrentUser($newAdmin['username'],$newAdmin['password'],$newAdmin['institution']);


### PR DESCRIPTION
The initial user setup fails with the error

```
Could not insert into user database: [22P02] 22P02 ERROR: invalid input
syntax for type boolean: "2"
```