### PR TITLE
Fix cannot create user as admin user.

### DIFF
--- a/grimas/grima-lib.php
+++ b/grimas/grima-lib.php
@@ -3234,6 +3234,9 @@ class GrimaUser extends GrimaDB {
 	public static function FromArray( $data ) {
 		$user = new GrimaUser();
 		foreach ( $data as $key => $val ) {
+			if ($key == "isadmin") {
+				$key = "isAdmin";
+			}
 			$user[$key] = $val;
 		}
 		return $user;


### PR DESCRIPTION
The check for admin user fails on Postgres DB because the users
table column 'isadmin' is not named 'isAdmin'.  Because we check for
'isADmin' return value we get a false negative.