### PR TITLE
Fix Could not insert into user database: [22P02] 22P02 ERROR: invalid…

### DIFF
--- a/grimas/grima-lib.php
+++ b/grimas/grima-lib.php
@@ -3354,12 +3354,15 @@ class GrimaUser extends GrimaDB {
 				"Could not even prepare to insert into user database: [$errorCode] {$errorInfo[0]} {$errorInfo[2]}"
 			);
 		}
-		$success = $query->execute( array(
-			'username' => $this['username'],
-			'password' => password_hash( $this['password'], $this->getPasswordAlgorithm() ),
-			'institution' => $this['institution'],
-			'isAdmin' => $this['isAdmin'],
-		) );
+
+		// Bindindg individually instead as ::execute() param to use specific type.
+		$query->bindValue('username', $this['username']);
+		$query->bindValue('password', password_hash( $this['password'], $this->getPasswordAlgorithm() ));
+		$query->bindValue('institution', $this['institution']);
+		$query->bindValue('isAdmin', $this['isAdmin'], \PDO::PARAM_BOOL);
+
+		$success = $query->execute();
+
 		if (!$success) {
 			$errorCode = $query->errorCode();
 			$errorInfo = $query->errorInfo();


### PR DESCRIPTION
… input syntax for type boolean:

This error happens because on $query->excute will bind any passed in
param to type string but 'isAdmin' needs to be of type BOOLEAN or it
throws on Postgres DB.